### PR TITLE
Allow to store objects in local storage

### DIFF
--- a/addon/initializer.js
+++ b/addon/initializer.js
@@ -1,5 +1,6 @@
 import Service from 'ember-preferences/service';
 import MemoryStorage from 'ember-preferences/storage/memory';
+import SerializableStorage from 'ember-preferences/storage/serializable';
 
 // FIXME: How can I test this? `window.localStorage = ...` is disabled in most browsers
 // See: https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API
@@ -17,9 +18,13 @@ function isLocalStorageAvailable() {
   return isAvailable;
 }
 
+function localStorage() {
+  return SerializableStorage.create({ content: window.localStorage });
+}
+
 export function initialize(application) {
   // Configure the service
-  var storage = isLocalStorageAvailable() ? window.localStorage : MemoryStorage.create();
+  var storage = isLocalStorageAvailable() ? localStorage() : MemoryStorage.create();
 
   application.register(
     'service:preferences',

--- a/addon/storage/serializable.js
+++ b/addon/storage/serializable.js
@@ -1,0 +1,27 @@
+import Ember from 'ember';
+
+export default Ember.Object.extend({
+  content: null,
+
+  setItem(key, value) {
+    return this.get('content').setItem(key, JSON.stringify(value));
+  },
+
+  getItem(key) {
+    var value = this.get('content').getItem(key);
+
+    if (typeof value === 'undefined' || value === null) {
+      return value;
+    }
+
+    return JSON.parse(value);
+  },
+
+  clear() {
+    this.get('content').clear();
+  },
+
+  removeItem(key) {
+    this.get('content').removeItem(key);
+  }
+});

--- a/tests/acceptance/application-test.js
+++ b/tests/acceptance/application-test.js
@@ -8,16 +8,22 @@ moduleForAcceptance('Acceptance | application', {
   }
 });
 
-test('visiting /', function(assert) {
+test('reads and writes to local storage, even complex values', function(assert) {
   visit('/');
 
   andThen(function() {
     assert.equal(find('h1').text(), 'Hello World!');
   });
 
-  click('button');
+  click('.simple-value');
 
   andThen(function() {
-    assert.equal(localStorage.getItem('title'), 'Hey Hey! Bye bye');
+    assert.equal(localStorage.getItem('title'), '"Hey Hey! Bye bye"');
+  });
+
+  click('.complex-value');
+
+  andThen(function() {
+    assert.equal(find('h2').text(), 'Complex value!');
   });
 });

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -5,8 +5,11 @@ export default Ember.Controller.extend({
   title: preference('title', { defaultValue: 'Hello World!' }),
 
   actions: {
-    updateTitle() {
+    simpleValue() {
       this.set('title', 'Hey Hey! Bye bye');
+    },
+    complexValue() {
+      this.set('title', { complex: 'Complex value!' });
     }
   }
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,6 @@
 <h1>{{title}}</h1>
-<button {{action 'updateTitle'}}>Update title</button>
+<button class="simple-value" {{action 'simpleValue'}}>Update simple value</button>
+
+<h2>{{title.complex}}</h2>
+<button class="complex-value" {{action 'complexValue'}}>Update complex value</button>
 {{outlet}}

--- a/tests/unit/initializer-test.js
+++ b/tests/unit/initializer-test.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import SerializableStorage from 'ember-preferences/storage/serializable';
 import { initialize } from 'dummy/instance-initializers/ember-preferences';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -37,5 +38,6 @@ test('registers localStorage as the storage', function(assert) {
   var service = application.resolveRegistration('service:preferences');
 
   assert.ok(service);
-  assert.equal(service.get('_storage'), window.localStorage);
+  assert.equal(service.get('_storage').constructor, SerializableStorage);
+  assert.equal(service.get('_storage.content'), window.localStorage);
 });

--- a/tests/unit/storage-memory-test.js
+++ b/tests/unit/storage-memory-test.js
@@ -1,11 +1,11 @@
 import { module, test } from 'qunit';
-import MemoryStore from 'ember-preferences/storage/memory';
+import MemoryStorage from 'ember-preferences/storage/memory';
 
 var subject;
 
 module('Unit | Storage | memory storage', {
   beforeEach() {
-    subject = MemoryStore.create();
+    subject = MemoryStorage.create();
   }
 });
 

--- a/tests/unit/storage-serializable-test.js
+++ b/tests/unit/storage-serializable-test.js
@@ -1,0 +1,75 @@
+import { module, test } from 'qunit';
+import MemoryStorage from 'ember-preferences/storage/memory';
+import SerializableStore from 'ember-preferences/storage/serializable';
+
+var subject,
+    actualStorage;
+
+module('Unit | Storage | memory storage', {
+  beforeEach() {
+    actualStorage = MemoryStorage.create();
+    subject = SerializableStore.create({ content: actualStorage });
+  }
+});
+
+test('serializes objects', function(assert) {
+  subject.setItem('foo', { bar: 'baz' });
+
+  assert.equal(actualStorage.getItem('foo'), '{"bar":"baz"}');
+});
+
+test('does not serialize undefined values', function(assert) {
+  subject.setItem('foo', undefined);
+
+  assert.equal(actualStorage.getItem('foo'), undefined);
+});
+
+test('does not serialize null values', function(assert) {
+  subject.setItem('foo', undefined);
+
+  assert.equal(actualStorage.getItem('foo'), undefined);
+});
+
+test('deserializes objects', function(assert) {
+  actualStorage.setItem('foo', '{"bar":"baz"}');
+
+  assert.deepEqual(subject.getItem('foo'), { bar: 'baz' });
+});
+
+test('does not try to deserialize undefined values', function(assert) {
+  assert.deepEqual(subject.getItem('foo'), undefined);
+});
+
+test('does not try to deserialize null values', function(assert) {
+  actualStorage.setItem('foo', null);
+
+  assert.deepEqual(subject.getItem('foo'), null);
+});
+
+test('clears the store', function(assert) {
+  subject.setItem('foo', { bar: 'baz' });
+  subject.clear();
+
+  assert.equal(subject.getItem('foo'), undefined);
+});
+
+test('removes item', function(assert) {
+  subject.setItem('foo', 'bar');
+  subject.removeItem('foo');
+
+  assert.equal(subject.getItem('foo'), undefined);
+});
+
+test('allows to store numbers', function(assert) {
+  subject.setItem('foo', 100);
+
+  assert.equal(subject.getItem('foo'), 100);
+});
+
+test('allows to store strings', function(assert) {
+  subject.setItem('foo', 'baz');
+  subject.setItem('bar', '100');
+
+  assert.equal(subject.getItem('foo'), 'baz');
+  assert.equal(subject.getItem('bar'), '100');
+});


### PR DESCRIPTION
Use JSON.stringify and JSON.parse to store and retrieve values from
session storage. This allows to store complex values

Fixes #5 
