### PR TITLE
Configure expiration times globally

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -186,3 +186,21 @@ export default function() {
   };
 }
 ```
+
+### Global expiration values
+
+You can configure expiration times for some keys by adding a map in the
+preferences configuration file.
+
+```js
+export default function() {
+  return {
+    expirations: {
+      foo() {
+        // one second in the future
+        return (+new Date()) + 1000;
+      }
+    }
+  };
+}
+```

--- a/addon/setup.js
+++ b/addon/setup.js
@@ -47,6 +47,7 @@ export function register(container, preferences) {
   }
 
   storage = ExpirableStorage.create({
+    expirations: preferences.expirations || {},
     content: storage
   });
 

--- a/addon/storage/expirable.js
+++ b/addon/storage/expirable.js
@@ -44,5 +44,19 @@ export default Ember.Object.extend(DecoratorMixin, {
     }
 
     return obj;
+  },
+
+  setItem(key, value) {
+    this._super(key, this.wrapValue(key, value));
+
+    return value;
+  },
+
+  wrapValue(key, value) {
+    if (this.get('expirations')[key]) {
+      return expirable(this.get('expirations')[key], value);
+    } else {
+      return value;
+    }
   }
 });

--- a/tests/unit/setup-test.js
+++ b/tests/unit/setup-test.js
@@ -89,12 +89,15 @@ if (isEmber2()) {
   });
 
   test('.register adds expirable decorator', function(assert) {
-    register(application, { });
+    let expirations = { foo() {} };
+
+    register(application, { expirations });
 
     let service = application.resolveRegistration('service:preferences');
     let decorator = find(service.get('_storage'), ExpirableStorage);
 
     assert.ok(decorator);
+    assert.deepEqual(decorator.get('expirations'), expirations);
   });
 
   test('.register adds serializable decorator', function(assert) {


### PR DESCRIPTION
Allow to configure expiration times in `preferences.js` file.
